### PR TITLE
Replace NumberFormatException control flow in NumericVersionFactory.create (#30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target/
 
 *.iml
+.DS_Store

--- a/src/main/java/org/octopusden/releng/versions/NumericVersionFactory.java
+++ b/src/main/java/org/octopusden/releng/versions/NumericVersionFactory.java
@@ -44,11 +44,13 @@ public class NumericVersionFactory {
      */
     private static Integer parseNonNegativeInt(String segment) {
         int length = segment.length();
-        if (length == 0) {
+        // Integer.parseInt accepts a single leading '+', so preserve that (a lone '+' is not a number).
+        int start = (length > 0 && segment.charAt(0) == '+') ? 1 : 0;
+        if (start == length) {
             return null;
         }
         long value = 0;
-        for (int i = 0; i < length; i++) {
+        for (int i = start; i < length; i++) {
             char c = segment.charAt(i);
             if (c < '0' || c > '9') {
                 return null;

--- a/src/main/java/org/octopusden/releng/versions/NumericVersionFactory.java
+++ b/src/main/java/org/octopusden/releng/versions/NumericVersionFactory.java
@@ -28,16 +28,37 @@ public class NumericVersionFactory {
 
         ArrayList<Integer> items = new ArrayList<>();
         for (String stringItem : strings) {
-            int item;
-            try {
-                item = Integer.parseInt(stringItem);
-            } catch (NumberFormatException e) {
-                continue;
-//                item = 0;
+            Integer item = parseNonNegativeInt(stringItem);
+            if (item != null) {
+                items.add(item);
             }
-            items.add(item);
         }
         return new NumericVersion(versionNames, items, rawVersion, rawVersion.endsWith("-SNAPSHOT"), rawVersion.endsWith("_RC"));
+    }
+
+    /**
+     * Parses a version segment as a non-negative {@code int} without using exceptions for control flow.
+     * Returns {@code null} for empty, non-numeric, or out-of-range segments (the common case for labelled
+     * versions such as {@code 1.2.3-rc1} or {@code 1.2.3.Final}), so the hot path does not throw and catch
+     * a {@link NumberFormatException} per segment on every call.
+     */
+    private static Integer parseNonNegativeInt(String segment) {
+        int length = segment.length();
+        if (length == 0) {
+            return null;
+        }
+        long value = 0;
+        for (int i = 0; i < length; i++) {
+            char c = segment.charAt(i);
+            if (c < '0' || c > '9') {
+                return null;
+            }
+            value = value * 10 + (c - '0');
+            if (value > Integer.MAX_VALUE) {
+                return null;
+            }
+        }
+        return (int) value;
     }
 
     public IVersionInfo create(int... elements) {

--- a/src/test/java/org/octopusden/releng/versions/NumericVersionTest.java
+++ b/src/test/java/org/octopusden/releng/versions/NumericVersionTest.java
@@ -71,6 +71,14 @@ class NumericVersionTest {
     }
 
     @Test
+    void testCreateFromIntElements() {
+        // create(int...) builds a dotted string and delegates to create(String).
+        assertThat(NUMBER_VERSION_FACTORY.create(1, 2, 3), equalTo(VERSION_1_2_3));
+        assertEquals(STR_V_1_2_3, NUMBER_VERSION_FACTORY.create(1, 2, 3).toString());
+        assertEquals(1, NUMBER_VERSION_FACTORY.create(1).getItemsCount());
+    }
+
+    @Test
     void testOutOfRangeSegmentIsSkipped() {
         // A digit-only segment that overflows int must be skipped, not parsed.
         assertEquals(2, version("1.99999999999999999.2").getItemsCount());

--- a/src/test/java/org/octopusden/releng/versions/NumericVersionTest.java
+++ b/src/test/java/org/octopusden/releng/versions/NumericVersionTest.java
@@ -59,6 +59,26 @@ class NumericVersionTest {
     }
 
     @Test
+    void testLabelledSegmentsAreSkipped() {
+        // Non-numeric segments must be dropped (not parsed), keeping only the numeric ones.
+        assertEquals(3, version("1.2.3-rc1").getItemsCount());
+        assertThat(1, equalTo(version("1.2.3-rc1").getItem(0)));
+        assertThat(2, equalTo(version("1.2.3-rc1").getItem(1)));
+        assertThat(3, equalTo(version("1.2.3-rc1").getItem(2)));
+
+        assertEquals(3, version("1.2.3.Final").getItemsCount());
+        assertEquals(4, version("name-1.2.3-456").getItemsCount());
+    }
+
+    @Test
+    void testOutOfRangeSegmentIsSkipped() {
+        // A digit-only segment that overflows int must be skipped, not parsed.
+        assertEquals(2, version("1.99999999999999999.2").getItemsCount());
+        assertThat(1, equalTo(version("1.99999999999999999.2").getItem(0)));
+        assertThat(2, equalTo(version("1.99999999999999999.2").getItem(1)));
+    }
+
+    @Test
     void testNull() {
         assertThrows(NullPointerException.class, ()-> version(null));
     }

--- a/src/test/java/org/octopusden/releng/versions/NumericVersionTest.java
+++ b/src/test/java/org/octopusden/releng/versions/NumericVersionTest.java
@@ -79,11 +79,33 @@ class NumericVersionTest {
     }
 
     @Test
+    void testLeadingPlusSegmentMatchesParseInt() {
+        // Integer.parseInt accepts a single leading '+', so the old parseInt-based code parsed
+        // such segments; behaviour must stay unchanged (issue #30).
+        assertEquals(2, version("+1.2").getItemsCount());
+        assertThat(1, equalTo(version("+1.2").getItem(0)));
+        assertThat(2, equalTo(version("+1.2").getItem(1)));
+        // a lone '+', a doubled '++3', or a misplaced '+' are not valid ints -> skipped, as before
+        assertEquals(2, version("1.+.2").getItemsCount());
+        assertEquals(2, version("1.++3.2").getItemsCount());
+    }
+
+    @Test
     void testOutOfRangeSegmentIsSkipped() {
         // A digit-only segment that overflows int must be skipped, not parsed.
         assertEquals(2, version("1.99999999999999999.2").getItemsCount());
         assertThat(1, equalTo(version("1.99999999999999999.2").getItem(0)));
         assertThat(2, equalTo(version("1.99999999999999999.2").getItem(1)));
+    }
+
+    @Test
+    void testIntBoundaryParsing() {
+        // Integer.MAX_VALUE is parsed; MAX_VALUE + 1 overflows and is skipped.
+        assertThat(Integer.MAX_VALUE, equalTo(version("1." + Integer.MAX_VALUE).getItem(1)));
+        assertEquals(1, version("1.2147483648").getItemsCount());
+        // Leading zeros are accepted (parseInt parity), even past 10 chars - a length check would be wrong.
+        assertThat(2, equalTo(version("1.00000000002").getItem(1)));
+        assertEquals(2, version("1.00000000002").getItemsCount());
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes #30.

`NumericVersionFactory.create(String)` parsed each version segment with `Integer.parseInt` inside a `try/catch` and used the thrown `NumberFormatException` as control flow to decide "numeric vs non-numeric". For any labelled version (`1.2.3-rc1`, `1.2.3.Final`, `name-1.2.3-456`) this threw and caught an NFE per non-numeric segment on **every** call — wasted allocation/throws on a hot path and noise in exception monitoring/APM for all downstream consumers of this shared library.

## Change
- Replace `parseInt` + `catch NumberFormatException` with a non-throwing `parseNonNegativeInt` helper that scans the segment for digits and returns `null` for empty, non-numeric, or out-of-range segments.
- Behaviour of the resulting `IVersionInfo` is unchanged — only the exception-as-control-flow is removed.
- Out-of-range all-digit segments (which previously threw NFE on overflow and were skipped) are still skipped, now without throwing.

## Tests
- All 109 existing tests pass (`mvn test`).
- Added `testLabelledSegmentsAreSkipped` and `testOutOfRangeSegmentIsSkipped` to pin the behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version parsing robustness by skipping invalid, non-numeric, and labeled segments rather than failing to parse.
  * Added exception-free segment validation, including ignoring oversized values beyond supported integer limits.
  * Preserves existing handling of suffix flags (e.g., `-SNAPSHOT` and `_RC`).
* **Tests**
  * Added coverage for skipping invalid segments, handling out-of-range numeric segments, and edge cases around leading `+` and `int` boundaries.
* **Chores**
  * Updated ignore rules to exclude macOS `.DS_Store` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->